### PR TITLE
Added an error-check and corrected parameter passing

### DIFF
--- a/GenFixture.py
+++ b/GenFixture.py
@@ -213,7 +213,7 @@ class GenFixture:
         if self.pivot_d != None:
             args += " -D\'pivot_d=%.02f\'" % float (self.pivot_d)
         if self.border != None:
-            args += " -D\'border=%.02f\'" % float (self.border)
+            args += " -D\'pcb_support_border=%.02f\'" % float (self.border)
 
         # Create output file name
         dxfout = path + "/" + self.prj_name + "-fixture.dxf"

--- a/GenFixture.py
+++ b/GenFixture.py
@@ -172,6 +172,13 @@ class GenFixture:
         # Get test points
         self.GetTestPoints ()
 
+        # Test for failure to find test points
+        if len(self.test_points) == 0:
+            print "WARNING, ABORTING: No test points found!"
+            print "Verify that the pcbnew file has test points specified"
+            print "or use the --flayer option to force test points"
+            return
+
         # Plot DXF
         self.PlotDXF (path)
 

--- a/openfixture.scad
+++ b/openfixture.scad
@@ -401,6 +401,10 @@ module head_top ()
         
         // Common base
         head_base_common ();
+
+        // Remove back cutout
+        translate ([2 * mat_th, head_y - mat_th, 0])
+        cube ([head_x - 4 * mat_th, mat_th, mat_th]);
         
         // Remove holes for hex nuts
         translate ([hole_offset, hole_offset, 0])


### PR DESCRIPTION
Verifying the number of test points is > 0 avoids silently generating a malformed test fixture.  Changing "border" to "pcb_support_border" allows the border specified in the shell script to be passed correctly to OpenSCAD.